### PR TITLE
Revamp connection code and enable IPv6

### DIFF
--- a/src/cry.ml
+++ b/src/cry.ml
@@ -428,7 +428,7 @@ let sockaddr_of_address address =
   | addr :: _ -> addr.ai_addr
 
 let resolve_host host port =
-  match Unix.getaddrinfo host (string_of_int port) [AI_FAMILY PF_INET; AI_SOCKTYPE SOCK_STREAM] with
+  match Unix.getaddrinfo host (string_of_int port) [AI_SOCKTYPE SOCK_STREAM] with
   | [] -> raise Not_found
   | l -> l
 

--- a/src/cry.ml
+++ b/src/cry.ml
@@ -531,7 +531,7 @@ let connect_icy c transport source =
     end;
     raise e
 
-let connect1 ?bind ?timeout sockaddr =
+let connect_sockaddr ?bind ?timeout sockaddr =
   let domain = Unix.domain_of_sockaddr sockaddr in
   let socket =
     try Unix.socket domain Unix.SOCK_STREAM 0
@@ -585,10 +585,10 @@ let do_connect ?bind ?timeout host port =
     | [] -> assert false
     | addr :: [] ->
        (* Let a possible error bubble up *)
-       connect1 ?bind ?timeout addr.ai_addr
+       connect_sockaddr ?bind ?timeout addr.ai_addr
     | addr :: tail ->
        try
-         connect1 ?bind ?timeout addr.ai_addr
+         connect_sockaddr ?bind ?timeout addr.ai_addr
        with _ ->
          connect_any ?bind ?timeout tail
   in connect_any ?bind ?timeout (resolve_host host port)

--- a/src/cry.mli
+++ b/src/cry.mli
@@ -64,7 +64,7 @@ exception Timeout
 
 (** Register a transport module to be used for SSL connections. *)
 val register_https :
-  (?timeout:float -> ?bind:string -> host:string -> Unix.sockaddr -> transport) ->
+  (host:string -> Unix.file_descr -> transport) ->
   unit
 
 (** Get a string explaining an error. *)


### PR DESCRIPTION
The main issue faced by @gilou in #5 was the use of Unix.gethostbyname, an API that can't cope with IPv6 connectivity.

Just replacing it with Unix.getaddrinfo isn't enough so the first commit is conservative.  The use of gethostbyname - spread over cry.ml and the https backends called for some some code reorg, see 5cf7523.  There I mostly moved code around, I hope I didn't break the code which moved from unix_transport to do_connect.

After making sure that destination and source address handling was done in a single place, 906e99b lets the user pick an IPv6 source address (not just IPv4), 736a25c applies the usual getaddrinfo loop pattern and finally a4fe563 unmasks IPv6 support.