### PR TITLE
Add support for SNI and modify Host header logic

### DIFF
--- a/src/cry.ml
+++ b/src/cry.ml
@@ -434,9 +434,9 @@ let resolve_host host port =
 let add_host_header ?(force = false) headers host port =
   try
     ignore (resolve_host host port);
-    if force then Hashtbl.replace headers "Host" ""
+    if force then Hashtbl.replace headers "Host" "" else Hashtbl.replace headers "Host" host
   with Not_found ->
-    let host = if port = 80 then host else Printf.sprintf "%s:%d" host port in
+    let host = if port = 80 || port = 443 then host else Printf.sprintf "%s:%d" host port in
     Hashtbl.replace headers "Host" host
 
 let http_path_of_mount = function

--- a/src/cry.ml
+++ b/src/cry.ml
@@ -446,8 +446,8 @@ let connect_http c transport source verb =
     let headers = Hashtbl.copy source.headers in
     Hashtbl.replace headers "Authorization" auth;
     add_host_header headers source.host source.port;
-    if source.chunked then Hashtbl.replace headers "Transfer-Encoding" "chunked" else
-      if verb = Put then Hashtbl.add headers "Expect" "100-continue";
+    if source.chunked then Hashtbl.replace headers "Transfer-Encoding" "chunked";
+    if verb = Put then Hashtbl.add headers "Expect" "100-continue";
     let headers = header_string headers source in
     let request =
       http_header (string_of_verb verb)

--- a/src/cry.ml
+++ b/src/cry.ml
@@ -431,9 +431,6 @@ let resolve_host host port =
     | [] -> raise Not_found
     | l -> List.rev l
 
-let add_host_header headers host port =
-  Hashtbl.replace headers "Host" (Printf.sprintf "%s:%d" host port)
-
 let http_path_of_mount = function
   | Icecast_mount mount -> mount
   | _ -> raise (Error Invalid_usage)
@@ -444,7 +441,7 @@ let connect_http c transport source verb =
     let http_version = if source.chunked then 1 else 0 in
     let headers = Hashtbl.copy source.headers in
     Hashtbl.replace headers "Authorization" auth;
-    add_host_header headers source.host source.port;
+    Hashtbl.replace headers "Host" (Printf.sprintf "%s:%d" source.host source.port);
     if source.chunked then Hashtbl.replace headers "Transfer-Encoding" "chunked";
     if verb = Put then Hashtbl.add headers "Expect" "100-continue";
     let headers = header_string headers source in

--- a/src/cry.ml
+++ b/src/cry.ml
@@ -432,8 +432,7 @@ let resolve_host host port =
     | l -> List.rev l
 
 let add_host_header headers host port =
-  let host = if port = 80 || port = 443 then host else Printf.sprintf "%s:%d" host port in
-  Hashtbl.replace headers "Host" host
+  Hashtbl.replace headers "Host" (Printf.sprintf "%s:%d" host port)
 
 let http_path_of_mount = function
   | Icecast_mount mount -> mount

--- a/src/cry.ml
+++ b/src/cry.ml
@@ -450,8 +450,8 @@ let connect_http c transport source verb =
     let headers = Hashtbl.copy source.headers in
     Hashtbl.replace headers "Authorization" auth;
     add_host_header ~force:(http_version = 1) headers source.host source.port;
-    if source.chunked then Hashtbl.replace headers "Transfer-Encoding" "chunked";
-    if verb = Put then Hashtbl.add headers "Expect" "100-continue";
+    if source.chunked then Hashtbl.replace headers "Transfer-Encoding" "chunked" else
+      if verb = Put then Hashtbl.add headers "Expect" "100-continue";
     let headers = header_string headers source in
     let request =
       http_header (string_of_verb verb)

--- a/src/cry.ml
+++ b/src/cry.ml
@@ -431,13 +431,9 @@ let resolve_host host port =
     | [] -> raise Not_found
     | l -> List.rev l
 
-let add_host_header ?(force = false) headers host port =
-  try
-    ignore (resolve_host host port);
-    if force then Hashtbl.replace headers "Host" "" else Hashtbl.replace headers "Host" host
-  with Not_found ->
-    let host = if port = 80 || port = 443 then host else Printf.sprintf "%s:%d" host port in
-    Hashtbl.replace headers "Host" host
+let add_host_header headers host port =
+  let host = if port = 80 || port = 443 then host else Printf.sprintf "%s:%d" host port in
+  Hashtbl.replace headers "Host" host
 
 let http_path_of_mount = function
   | Icecast_mount mount -> mount
@@ -449,7 +445,7 @@ let connect_http c transport source verb =
     let http_version = if source.chunked then 1 else 0 in
     let headers = Hashtbl.copy source.headers in
     Hashtbl.replace headers "Authorization" auth;
-    add_host_header ~force:(http_version = 1) headers source.host source.port;
+    add_host_header headers source.host source.port;
     if source.chunked then Hashtbl.replace headers "Transfer-Encoding" "chunked" else
       if verb = Put then Hashtbl.add headers "Expect" "100-continue";
     let headers = header_string headers source in

--- a/src/cry_https.ssl.ml
+++ b/src/cry_https.ssl.ml
@@ -25,14 +25,14 @@ let () =
   Ssl.init ()
 
 let register fn =
-  let connect_ssl ~host:_ socket =
+  let connect_ssl ~host:hostname socket =
     let ctx = Ssl.create_context Ssl.SSLv23 Ssl.Client_context in
     (* SSL_VERIFY_NONE is default in shout. TODO: add option.. *)
     Ssl.set_verify ctx [] (Some Ssl.client_verify_callback);
     Ssl.set_verify_depth ctx 3;
     ignore (Ssl.set_default_verify_paths ctx);
     let ssl = Ssl.embed_socket socket ctx in
-    Ssl.set_client_SNI_hostname ssl ~host
+    Ssl.set_client_SNI_hostname ssl hostname; 
     Ssl.connect ssl;
     let shutdown () =
       Ssl.shutdown ssl;

--- a/src/cry_https.ssl.ml
+++ b/src/cry_https.ssl.ml
@@ -32,6 +32,7 @@ let register fn =
     Ssl.set_verify_depth ctx 3;
     ignore (Ssl.set_default_verify_paths ctx);
     let ssl = Ssl.embed_socket socket ctx in
+    Ssl.set_client_SNI_hostname ssl ~host
     Ssl.connect ssl;
     let shutdown () =
       Ssl.shutdown ssl;


### PR DESCRIPTION
First time touching ocaml -- I'm pretty confident in the change regarding SNI being fairly harmless -- I'm not certain what the purpose of the existing "Host" header logic is though.

Today it seems to only put a host header in the event resolve_host returns Not_Found? I'm also not sure why the host header is empty by default.  I'd propose simplifying to just always set the Host header but the context here is probably important...